### PR TITLE
feat(not)

### DIFF
--- a/src/not/__snapshots__/not.spec.ts.snap
+++ b/src/not/__snapshots__/not.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`not function is a pure function 1`] = `
+Array [
+  1,
+  2,
+  3,
+  4,
+  5,
+]
+`;

--- a/src/not/index.ts
+++ b/src/not/index.ts
@@ -1,0 +1,1 @@
+export * from './not';

--- a/src/not/not.spec.ts
+++ b/src/not/not.spec.ts
@@ -1,0 +1,22 @@
+import { map } from '../map';
+import { not } from './not';
+
+describe('not function', () => {
+  const input = [1, 2, 3, 4, 5];
+  const isEven = (x: number): boolean => 0 === x % 2;
+
+  test('is a pure function', () => {
+    map(not(isEven))(input);
+    expect(input).toMatchSnapshot();
+  });
+
+  test('1 |> not === 1', () => {
+    expect(not(isEven)(1)).toBe(true);
+  });
+
+  test('x |> not(predicat) calls the predicat', () => {
+    const predicat = jest.fn().mockReturnValue(true);
+    not(predicat)('foo');
+    expect(predicat).toHaveBeenCalledWith('foo');
+  });
+});

--- a/src/not/not.ts
+++ b/src/not/not.ts
@@ -1,0 +1,27 @@
+/**
+ * @module any=>boolean
+ */
+/**
+ * This method return the negation of the boolean result of the passed function,
+ * ie: !predicat(x)
+ * @param predicat The function that return a boolean.
+ * @return the function to apply on the input to return the negation
+ * @example
+ * ```
+ * const isEven = x => 0 === x % 2;
+ * const isOdd = not<number>(isEven);
+ * isOdd(1) // true
+ * ```
+ * @example Using the chain
+ * ```
+ * const isEven = x => 0 === x % 2;
+ * chain([1, 2, 3, 4])
+ *   .chain(filter(not(isEven))
+ *   .value() // [1, 3]
+ * ```
+ */
+export function not<T>(
+  predicat: (element: T) => boolean
+): (element: T) => boolean {
+  return (element: T) => !predicat(element);
+}

--- a/src/taninsam.ts
+++ b/src/taninsam.ts
@@ -29,6 +29,7 @@ export * from './max';
 export * from './max-by';
 export * from './min';
 export * from './min-by';
+export * from './not';
 export * from './partition';
 export * from './pop';
 export * from './push';


### PR DESCRIPTION
not enforces the way to not reimplement the negation when a function returns the negation of what we
want to test